### PR TITLE
Fixed circular dependency with i18n

### DIFF
--- a/src/app/public/modules/numeric/numeric.pipe.spec.ts
+++ b/src/app/public/modules/numeric/numeric.pipe.spec.ts
@@ -9,7 +9,7 @@ import {
 
 import {
   SkyLibResourcesService
-} from '@skyux/i18n';
+} from '@skyux/i18n/modules/i18n/lib-resources.service';
 
 import {
   SkyLibResourcesTestService

--- a/src/app/public/modules/numeric/numeric.pipe.spec.ts
+++ b/src/app/public/modules/numeric/numeric.pipe.spec.ts
@@ -13,7 +13,7 @@ import {
 
 import {
   SkyLibResourcesTestService
-} from '@skyux/i18n/testing';
+} from '@skyux/i18n/testing/lib-resources-test.service';
 
 import {
   SkyNumericPipe

--- a/src/app/public/modules/numeric/numeric.service.spec.ts
+++ b/src/app/public/modules/numeric/numeric.service.spec.ts
@@ -5,7 +5,7 @@ import {
 
 import {
   SkyLibResourcesTestService
-} from '@skyux/i18n/testing';
+} from '@skyux/i18n/testing/lib-resources-test.service';
 
 import {
   NumericOptions

--- a/src/app/public/modules/numeric/numeric.service.ts
+++ b/src/app/public/modules/numeric/numeric.service.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   SkyLibResourcesService
-} from '@skyux/i18n';
+} from '@skyux/i18n/modules/i18n/lib-resources.service';
 
 import {
   NumericOptions

--- a/src/app/public/modules/shared/core-resources.module.ts
+++ b/src/app/public/modules/shared/core-resources.module.ts
@@ -4,7 +4,7 @@ import {
 
 import {
   SKY_LIB_RESOURCES_PROVIDERS
-} from '@skyux/i18n';
+} from '@skyux/i18n/modules/i18n/lib-resources-providers-token';
 
 import {
   SkyCoreResourcesProvider

--- a/src/app/public/plugin-resources/core-resources-provider.ts
+++ b/src/app/public/plugin-resources/core-resources-provider.ts
@@ -1,7 +1,10 @@
 import {
-  SkyAppLocaleInfo,
   SkyLibResourcesProvider
-} from '@skyux/i18n';
+} from '@skyux/i18n/modules/i18n/lib-resources-provider';
+
+import {
+  SkyAppLocaleInfo
+} from '@skyux/i18n/modules/i18n/locale-info';
 
 export class SkyCoreResourcesProvider implements SkyLibResourcesProvider {
   public getString: (localeInfo: SkyAppLocaleInfo, name: string) => string;


### PR DESCRIPTION
If you install both `@skyux/i18n` and `@skyux/core` in the same project, they throw an error in the console regarding a circular dependency. This can be alleviated by importing from the direct file, instead of using the barrel **index.ts** files.