### PR TITLE
Added a safer rounding function

### DIFF
--- a/src/app/public/modules/numeric/numeric.service.spec.ts
+++ b/src/app/public/modules/numeric/numeric.service.spec.ts
@@ -256,4 +256,70 @@ describe('Numeric service', () => {
     options.digits = 4;
     expect(skyNumeric.formatNumber(value, options)).toBe('1.0001');
   });
+​
+  describe('roundNumber', () => {
+    it('returns 0 if the value is not a number', function() {
+      // tslint:disable-next-line:no-null-keyword
+      expect(skyNumeric.roundNumber(null, 2)).toBe(0);
+      expect(skyNumeric.roundNumber(undefined, 2)).toBe(0);
+    });
+    it('throws an error if precision is less than 0', function() {
+      try {
+        skyNumeric.roundNumber(1.003, -5);
+        fail('It should fail!');
+      } catch (err) {
+        expect(err.message).toEqual('SkyInvalidArgument: precision must be >= 0');
+      }
+    });
+    it('rounds with a default precision of 0', () => {
+        expect(skyNumeric.roundNumber(123)).toBe(123);
+        expect(skyNumeric.roundNumber(0.75)).toBe(1);
+        expect(skyNumeric.roundNumber(1.005)).toBe(1);
+        expect(skyNumeric.roundNumber(1.3555)).toBe(1);
+        expect(skyNumeric.roundNumber(1.001)).toBe(1);
+        expect(skyNumeric.roundNumber(1.77777)).toBe(2);
+        expect(skyNumeric.roundNumber(9.1)).toBe(9);
+        expect(skyNumeric.roundNumber(1234.5678)).toBe(1235);
+        expect(skyNumeric.roundNumber(1.5383)).toBe(2);
+        expect(skyNumeric.roundNumber(-1.5383)).toBe(-2);
+        expect(skyNumeric.roundNumber(1.5e3)).toBe(1500);
+        expect(skyNumeric.roundNumber(-1.5e3)).toBe(-1500);
+    });
+    it('rounds correctly when passed a custom precision', () => {
+        expect(skyNumeric.roundNumber(123, 0)).toBe(123);
+        expect(skyNumeric.roundNumber(123.34, 0)).toBe(123);
+        expect(skyNumeric.roundNumber(0.75, 1)).toBe(0.8);
+        expect(skyNumeric.roundNumber(1.005, 1)).toBe(1.0);
+        expect(skyNumeric.roundNumber(0.75, 2)).toBe(0.75);
+        expect(skyNumeric.roundNumber(1.005, 2)).toBe(1.01);
+        expect(skyNumeric.roundNumber(1.3555, 2)).toBe(1.36);
+        expect(skyNumeric.roundNumber(1.001, 2)).toBe(1.00);
+        expect(skyNumeric.roundNumber(1.77777, 2)).toBe(1.78);
+        expect(skyNumeric.roundNumber(9.1, 2)).toBe(9.1);
+        expect(skyNumeric.roundNumber(1234.5678, 2)).toBe(1234.57);
+        expect(skyNumeric.roundNumber(1.5383, 1)).toBe(1.5);
+        expect(skyNumeric.roundNumber(1.5383, 2)).toBe(1.54);
+        expect(skyNumeric.roundNumber(1.5383, 3)).toBe(1.538);
+        expect(skyNumeric.roundNumber(-1.5383, 1)).toBe(-1.5);
+        expect(skyNumeric.roundNumber(-1.5383, 2)).toBe(-1.54);
+        expect(skyNumeric.roundNumber(-1.5383, 3)).toBe(-1.538);
+        expect(skyNumeric.roundNumber(-0.75, 2)).toBe(-0.75);
+        expect(skyNumeric.roundNumber(-0.75, 3)).toBe(-0.75);
+        expect(skyNumeric.roundNumber(1.5e3, 2)).toBe(1500);
+        expect(skyNumeric.roundNumber(-1.5e3, 2)).toBe(-1500);
+    });
+    it('rounds really small numbers', () => {
+        expect(skyNumeric.roundNumber(0.000000000000007, 4)).toBe(0.0000);
+        expect(skyNumeric.roundNumber(-0.000000000000007, 4)).toBe(0.0000);
+        expect(skyNumeric.roundNumber(7e-15, 4)).toBe(0.0000);
+        expect(skyNumeric.roundNumber(-7e-15, 4)).toBe(0.0000);
+    });
+    it('rounds really big numbers', function () {
+      expect(skyNumeric.roundNumber(700000000000000000000.324, 2)).toBe(700000000000000000000.32);
+      expect(skyNumeric.roundNumber(700000000000000000000.324, 3)).toBe(700000000000000000000.324);
+      expect(skyNumeric.roundNumber(3518437208882.663, 2)).toBe(3518437208882.66);
+      expect(skyNumeric.roundNumber(2.5368e15, 1)).toBe(2536800000000000);
+      expect(skyNumeric.roundNumber(2536800000000000.119, 2)).toBe(2536800000000000.12);
+    });
+  });
 });

--- a/src/app/public/modules/numeric/numeric.service.ts
+++ b/src/app/public/modules/numeric/numeric.service.ts
@@ -34,21 +34,15 @@ export class SkyNumericService {
   ];
 
   private defaultLocale = 'en-US';
-
-  constructor(
-    private resourcesService: SkyLibResourcesService
-  ) { }
-
+​
+  constructor(private resourcesService: SkyLibResourcesService) { }
+​
   /**
    * Shortens with or without symbol (K/M/B/T) depending on value of number.
    * @param value The number to format.
    * @param options Format options.
    */
-  public formatNumber(
-    value: number,
-    options: NumericOptions
-  ): string {
-
+  public formatNumber(value: number, options: NumericOptions): string {
     /* tslint:disable-next-line:no-null-keyword */
     if (isNaN(value) || value === null) {
       return '';
@@ -66,21 +60,12 @@ export class SkyNumericService {
     });
 
     let output: string;
-
     if (symbol) {
-      output = Number(
-        // Using Math.round to ensure accurate rounding compared to toFixed.
-        Math.round(
-          parseFloat((value / symbol.value) + `e${options.digits}`)
-        ) + `e-${options.digits}`
-      ).toString().replace(decimalPlaceRegExp, '$1') + symbol.label;
-
+      const roundedNumber: number = this.roundNumber((value / symbol.value), options.digits);
+      output = roundedNumber.toString().replace(decimalPlaceRegExp, '$1') + symbol.label;
     } else {
-      output = Number(
-        Math.round(
-          parseFloat(`${value}e${options.digits}`)
-        ) + `e-${options.digits}`
-      ).toString().replace(decimalPlaceRegExp, '$1');
+      const roundedNumber: number = this.roundNumber(value, options.digits);
+      output = roundedNumber.toString().replace(decimalPlaceRegExp, '$1');
     }
 
     this.storeShortenSymbol(output);
@@ -152,6 +137,51 @@ export class SkyNumericService {
     return output;
   }
 
+  /**
+   * Rounds a given number
+   *
+   * JS's limitation - numbers bigger than Number.MIN_SAFE_INTEGER or Number.MAX_SAFE_INTEGER
+   * are not guaranteed to be represented or rounded correctly
+   * @param value - value to round
+   * @param precision - what precision to round with, defaults to 0 decimal places
+   */
+  public roundNumber(value: number, precision: number = 0): number {
+    if (precision < 0) { throw new Error('SkyInvalidArgument: precision must be >= 0'); }
+​
+    /* tslint:disable-next-line:no-null-keyword */
+    if (isNaN(value) || value === null) { return 0; }
+​
+    const scaledValue: number = this.scaleNumberByPowerOfTen(value, precision, true);
+    const scaledRoundedValue: number = Math.round(scaledValue);
+    const unscaledRoundedValue: number = this.scaleNumberByPowerOfTen(
+      scaledRoundedValue,
+      precision,
+      false
+    );
+​
+    return unscaledRoundedValue;
+  }
+​
+  /**
+   * Scales a given number by a power of 10
+   * @param value - value to scale
+   * @param scalar - 10^scalar
+   * @param scaleUp - whether to increase or decrease the value
+   */
+  private scaleNumberByPowerOfTen(value: number, scalar: number, scaleUp: boolean): number {
+    const valueStr: string = value.toString().toLowerCase();
+    const isExponentFormat: boolean = valueStr.includes('e');
+​
+    if (isExponentFormat) {
+      const [base, exp] = valueStr.split('e');
+      const newExp = scaleUp ? (Number(exp) + scalar) : (Number(exp) - scalar);
+      return Number(`${base}e${newExp}`);
+    } else {
+      const e = scaleUp ? 'e'  : 'e-';
+      return Number(`${value}${e}${scalar}`);
+    }
+  }
+​
   /**
    * Stores the symbol added from shortening to reapply later.
    * @param value The string to derive the shorten symbol from.


### PR DESCRIPTION
## Description
This is a bug fix to a similar issue that I fixed in **FENXT** a few months ago that deals with rounding floating point numbers in javascript.

The function as it is now will work for small values / small levels of precision (digits) but once either of those get really big (in terms of absolute value) Javascript has some funky behavior.

- For example, if you go into your JS console and type `1500000000000000000000` it will convert it to `1.5e+21`. 
- If you were to pass that value into the rounding function it will attempt to append an `e` to the value but because the value is already formatted in exponential form (thanks to JS) it will end up breaking and will return  `NAN`.

## The Fix
- The fix revolves using the same scaling logic but identifying whether the number is formatted in exponential notation already.
- I encapsulated the rounding logic into its own method to clean up the code.
- I decided to make the `roundNumber` function public because rounding in JS is a huge problem and I believe it should be standardized in some way so that consumers do not have to hand-roll their own versions of this logic.

### More Comments
`7/31/2019`: 
  - Also, keep in mind this is not a _perfect_ solution because javascript is an imperfect language. There are still boundaries you can cross (`Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`) which will break rounding.
- The range of valid values that the rounding function can support is ultimately dictated by `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` as well as the precision (decimal places to round) passed in. The higher the precision, the higher that the number has to be scaled/unscaled in order to round it which means the number, once scaled, could be outside the safe boundaries.  
- And to clarify, all of these issues are present in the initial solution before I made my changes.