### PR TITLE
Added arguments to getFocusableChildren

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Thank you for your interest in contributing to SKY UX!
+
+For the suggested workflow, coding conventions, and additional guidance, please see our [contribution guidelines](https://developer.blackbaud.com/skyux/contribute/contribution-process).

--- a/src/app/public/modules/adapter-service/adapter.service.spec.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.spec.ts
@@ -1,0 +1,189 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
+  SkyMediaBreakpoints
+} from '@skyux/core';
+
+import {
+  AdapterServiceFixtureComponent
+} from './fixtures/adapter-service.fixture';
+
+import {
+  SkyAdapterServiceFixturesModule
+} from './fixtures/adapter-service.fixtures.module';
+
+describe('Core adapter service', () => {
+  let fixture: ComponentFixture<AdapterServiceFixtureComponent>;
+  let component: AdapterServiceFixtureComponent;
+  let nativeElement: any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SkyAdapterServiceFixturesModule
+      ]
+    });
+    fixture = TestBed.createComponent(AdapterServiceFixtureComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.nativeElement;
+  });
+
+  describe('getFocusableChildren', () => {
+    it('should return an array of all focusable children', () => {
+      const actual = component.getFocusableChildren(nativeElement);
+      expect(actual.length).toEqual(5);
+    });
+
+    it('should not return any tabIndex with -1', () => {
+      const inputs = nativeElement.querySelectorAll('input');
+      const links = nativeElement.querySelectorAll('a');
+
+      inputs[0].tabIndex = '-1';
+      links[0].tabIndex = '-1';
+
+      const actual = component.getFocusableChildren(nativeElement);
+      expect(actual.length).toEqual(3);
+    });
+
+    it('should ignore tabIndexes when ignoreTabIndex = true', () => {
+      const inputs = nativeElement.querySelectorAll('input');
+      const links = nativeElement.querySelectorAll('a');
+
+      inputs[0].tabIndex = '-1';
+      links[0].tabIndex = '-1';
+
+      const actual = component.getFocusableChildren(nativeElement, {ignoreTabIndex: true});
+      expect(actual.length).toEqual(5);
+    });
+
+    it('should not return hidden elements with default settings', () => {
+      const hiddenContainer = nativeElement.querySelector('#hidden-container');
+      const actual = component.getFocusableChildren(hiddenContainer);
+      expect(actual.length).toEqual(0);
+    });
+
+    it('should return hidden elements when ignoreVisibility = true', () => {
+      const actual = component.getFocusableChildren(nativeElement, {ignoreVisibility: true});
+      expect(actual.length).toEqual(6);
+    });
+  });
+
+  describe('getFocusableChildrenAndApplyFocus', () => {
+    it('should apply focus to the first element', () => {
+      const firstFocussableElement = nativeElement.querySelector('#not-autofocus-input');
+
+      component.getFocusableChildrenAndApplyFocus(fixture, '#focusable-children-container');
+
+      expect(document.activeElement).toEqual(firstFocussableElement);
+    });
+
+    it('should apply focus to the container if no focussable element is found', () => {
+      const container = nativeElement.querySelector('#paragraph-container');
+
+      component.getFocusableChildrenAndApplyFocus(fixture, '#paragraph-container', true);
+
+      expect(document.activeElement).toEqual(container);
+    });
+  });
+
+  describe('applyAutoFocus', () => {
+    it('should apply focus to the first autofocus element and return true', () => {
+      const nonAutoFocusInput = nativeElement.querySelector('#not-autofocus-input');
+      const autoFocusElement = nativeElement.querySelector('#autofocus-input');
+
+      // Set focus to something else for a baseline.
+      nonAutoFocusInput.focus();
+      expect(document.activeElement).toEqual(nonAutoFocusInput);
+
+      // Run applyAutoFocus.
+      const actual = component.applyAutoFocus(fixture);
+
+      // Expect focus to be back on the autofocus input.
+      expect(document.activeElement).toEqual(autoFocusElement);
+      expect(actual).toEqual(true);
+    });
+
+    it('should not apply focus if no autofocus element is found and return false', () => {
+      const nonAutoFocusInput = nativeElement.querySelector('#not-autofocus-input');
+      const autoFocusElement = nativeElement.querySelector('#autofocus-input');
+
+      // Set focus to something else for a baseline.
+      nonAutoFocusInput.focus();
+      expect(document.activeElement).toEqual(nonAutoFocusInput);
+
+      // Remove the autofocus element from DOM. Run applyAutoFocus.
+      autoFocusElement.remove();
+      const actual = component.applyAutoFocus(fixture);
+
+      // Expect focus to have not been moved.
+      expect(document.activeElement).toEqual(nonAutoFocusInput);
+      expect(actual).toEqual(false);
+    });
+  });
+
+  describe('toggleIframePointerEvents', () => {
+    it('should set the pointerEvents style to "none" when value is false', () => {
+      const iframe = nativeElement.querySelector('#iframe-container iframe');
+
+      // Expect baseline CSS value to be an empty string.
+      expect(iframe.style.pointerEvents).toEqual('');
+
+      // Set the value to false and expect CSS value to be 'none'.
+      component.toggleIframePointerEvents(false);
+      expect(iframe.style.pointerEvents).toEqual('none');
+
+      // Set the value to true and expect CSS value to be back to the baseline empty string.
+      component.toggleIframePointerEvents(true);
+      expect(iframe.style.pointerEvents).toEqual('');
+    });
+  });
+
+  describe('setResponsiveContainerClass', () => {
+    it('should set xs CSS class', () => {
+      const container = nativeElement.querySelector('#paragraph-container');
+      component.setParagraphContainerClass(SkyMediaBreakpoints.xs);
+
+      expect(container).toHaveCssClass('sky-responsive-container-xs');
+      expect(container).not.toHaveCssClass('sky-responsive-container-sm');
+      expect(container).not.toHaveCssClass('sky-responsive-container-md');
+      expect(container).not.toHaveCssClass('sky-responsive-container-lg');
+    });
+
+    it('should set sm CSS class', () => {
+      const container = nativeElement.querySelector('#paragraph-container');
+      component.setParagraphContainerClass(SkyMediaBreakpoints.sm);
+
+      expect(container).not.toHaveCssClass('sky-responsive-container-xs');
+      expect(container).toHaveCssClass('sky-responsive-container-sm');
+      expect(container).not.toHaveCssClass('sky-responsive-container-md');
+      expect(container).not.toHaveCssClass('sky-responsive-container-lg');
+    });
+
+    it('should set md CSS class', () => {
+      const container = nativeElement.querySelector('#paragraph-container');
+      component.setParagraphContainerClass(SkyMediaBreakpoints.md);
+
+      expect(container).not.toHaveCssClass('sky-responsive-container-xs');
+      expect(container).not.toHaveCssClass('sky-responsive-container-sm');
+      expect(container).toHaveCssClass('sky-responsive-container-md');
+      expect(container).not.toHaveCssClass('sky-responsive-container-lg');
+    });
+
+    it('should set lg CSS class', () => {
+      const container = nativeElement.querySelector('#paragraph-container');
+      component.setParagraphContainerClass(SkyMediaBreakpoints.lg);
+
+      expect(container).not.toHaveCssClass('sky-responsive-container-xs');
+      expect(container).not.toHaveCssClass('sky-responsive-container-sm');
+      expect(container).not.toHaveCssClass('sky-responsive-container-md');
+      expect(container).toHaveCssClass('sky-responsive-container-lg');
+    });
+  });
+});

--- a/src/app/public/modules/adapter-service/adapter.service.spec.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.spec.ts
@@ -119,7 +119,7 @@ describe('Core adapter service', () => {
       expect(document.activeElement).toEqual(nonAutoFocusInput);
 
       // Remove the autofocus element from DOM. Run applyAutoFocus.
-      autoFocusElement.remove();
+      autoFocusElement.parentNode.removeChild(autoFocusElement);
       const actual = component.applyAutoFocus(fixture);
 
       // Expect focus to have not been moved.

--- a/src/app/public/modules/adapter-service/adapter.service.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.ts
@@ -9,6 +9,10 @@ import {
   SkyMediaBreakpoints
 } from '../media-query';
 
+import {
+  SkyFocusableChildrenOptions
+} from './focusable-children-options';
+
 const SKY_TABBABLE_SELECTOR = [
   'a[href]',
   'area[href]',
@@ -148,25 +152,18 @@ export class SkyCoreAdapterService {
    * Returns an array of all focusable children of provided `element`.
    *
    * @param element - The HTMLElement to search within.
-   * @param ignoreTabIndex - By default, this function will filter out elements with
-   * a `tabIndex` of `-1`. Setting `ignoreTabIndex = true` will ignore this filter.
-   * @param ignoreVisibility - By default, this function will only return visible elements.
-   * Setting `ignoreVisibility = true` will ignore this filter.
+   * @param options - Options for getting focusable children.
    */
-  public getFocusableChildren(
-    element: HTMLElement,
-    ignoreTabIndex: boolean = false,
-    ignoreVisibility: boolean = false
-  ): HTMLElement[] {
+  public getFocusableChildren(element: HTMLElement, options?: SkyFocusableChildrenOptions): HTMLElement[] {
     let elements: Array<HTMLElement>;
 
-    if (ignoreTabIndex) {
+    if (options && options.ignoreTabIndex) {
       elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR_IGNORE_TABINDEX));
     } else {
       elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR));
     }
 
-    if (ignoreVisibility) {
+    if (options && options.ignoreVisibility) {
       return elements;
     }
 

--- a/src/app/public/modules/adapter-service/adapter.service.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.ts
@@ -14,19 +14,6 @@ import {
 } from './focusable-children-options';
 
 const SKY_TABBABLE_SELECTOR = [
-  'a[href]:not([tabindex=\'-1\'])',
-  'area[href]:not([tabindex=\'-1\'])',
-  'input:not([disabled]):not([tabindex=\'-1\'])',
-  'button:not([disabled]):not([tabindex=\'-1\'])',
-  'select:not([disabled]):not([tabindex=\'-1\'])',
-  'textarea:not([disabled]):not([tabindex=\'-1\'])',
-  'iframe:not([tabindex=\'-1\'])',
-  'object:not([tabindex=\'-1\'])',
-  'embed:not([tabindex=\'-1\'])',
-  '*[contenteditable=true]'
-].join(', ');
-
-const SKY_TABBABLE_SELECTOR_IGNORE_TABINDEX = [
   'a[href]',
   'area[href]',
   'input:not([disabled])',
@@ -154,21 +141,23 @@ export class SkyCoreAdapterService {
    * @param options - Options for getting focusable children.
    */
   public getFocusableChildren(element: HTMLElement, options?: SkyFocusableChildrenOptions): HTMLElement[] {
-    let elements: Array<HTMLElement>;
+    let elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR));
 
-    if (options && options.ignoreTabIndex) {
-      elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR_IGNORE_TABINDEX));
-    } else {
-      elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR));
+    // Unless ignoreTabIndex = true, filter out elements with tabindex = -1.
+    if (!options || !options.ignoreTabIndex) {
+      elements = elements.filter((el: HTMLElement) => {
+        return el.tabIndex !== -1;
+      });
     }
 
-    if (options && options.ignoreVisibility) {
-      return elements;
+    // Unless ignoreVisibility = true, filter out elements that are not visible.
+    if (!options || !options.ignoreVisibility) {
+      elements = elements.filter((el: HTMLElement) => {
+        return this.isVisible(el);
+      });
     }
 
-    return elements.filter((el) => {
-      return this.isVisible(el);
-    });
+    return elements;
   }
 
   private focusFirstElement(list: Array<HTMLElement>): boolean {

--- a/src/app/public/modules/adapter-service/adapter.service.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.ts
@@ -23,6 +23,19 @@ const SKY_TABBABLE_SELECTOR = [
   '*[contenteditable=true]'
 ].join(', ');
 
+const SKY_TABBABLE_SELECTOR_IGNORE_TABINDEX = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled])',
+  'button:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '*[contenteditable=true]'
+].join(', ');
+
 @Injectable()
 export class SkyCoreAdapterService {
 
@@ -135,10 +148,27 @@ export class SkyCoreAdapterService {
    * Returns an array of all focusable children of provided `element`.
    *
    * @param element - The HTMLElement to search within.
+   * @param ignoreTabIndex - By default, this function will filter out elements with
+   * a `tabIndex` of `-1`. Setting `ignoreTabIndex = true` will ignore this filter.
+   * @param ignoreVisibility - By default, this function will only return visible elements.
+   * Setting `ignoreVisibility = true` will ignore this filter.
    */
-  public getFocusableChildren(element: HTMLElement): HTMLElement[] {
-    const elements: Array<HTMLElement>
-      = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR));
+  public getFocusableChildren(
+    element: HTMLElement,
+    ignoreTabIndex: boolean = false,
+    ignoreVisibility: boolean = false
+  ): HTMLElement[] {
+    let elements: Array<HTMLElement>;
+
+    if (ignoreTabIndex) {
+      elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR_IGNORE_TABINDEX));
+    } else {
+      elements = Array.prototype.slice.call(element.querySelectorAll(SKY_TABBABLE_SELECTOR));
+    }
+
+    if (ignoreVisibility) {
+      return elements;
+    }
 
     return elements.filter((el) => {
       return this.isVisible(el);

--- a/src/app/public/modules/adapter-service/adapter.service.ts
+++ b/src/app/public/modules/adapter-service/adapter.service.ts
@@ -14,16 +14,15 @@ import {
 } from './focusable-children-options';
 
 const SKY_TABBABLE_SELECTOR = [
-  'a[href]',
-  'area[href]',
+  'a[href]:not([tabindex=\'-1\'])',
+  'area[href]:not([tabindex=\'-1\'])',
   'input:not([disabled]):not([tabindex=\'-1\'])',
   'button:not([disabled]):not([tabindex=\'-1\'])',
   'select:not([disabled]):not([tabindex=\'-1\'])',
   'textarea:not([disabled]):not([tabindex=\'-1\'])',
-  'iframe',
-  'object',
-  'embed',
-  '*[tabindex]:not([tabindex=\'-1\'])',
+  'iframe:not([tabindex=\'-1\'])',
+  'object:not([tabindex=\'-1\'])',
+  'embed:not([tabindex=\'-1\'])',
   '*[contenteditable=true]'
 ].join(', ');
 

--- a/src/app/public/modules/adapter-service/fixtures/adapter-service.fixture.html
+++ b/src/app/public/modules/adapter-service/fixtures/adapter-service.fixture.html
@@ -1,0 +1,45 @@
+<h1>Adapter service fixture</h1>
+
+<div
+  id="focusable-children-container"
+>
+  <p>Hello world</p>
+  <input
+    id="not-autofocus-input"
+    name="not-autofocus-input"
+    type="text"
+  />
+  <p>Here's a <a href="#">link</a> that doesn't have autofocus.</p>
+  <input
+    autofocus
+    id="autofocus-input"
+    name="autofocus-input"
+    type="text"
+  />
+  <p>Here's another <a href="#">link</a> that doesn't have autofocus.</p>
+  <p>Goodbye!</p>
+</div>
+
+<div
+  id="hidden-container"
+  style="display:none; visibility: hidden;"
+>
+  <p>You shouldn't see this <a href="#">link</a>!</p>
+</div>
+
+<div
+  id="paragraph-container"
+  tabindex="0"
+  #paragraphContainer
+>
+  <h2>I'm a responsive container!</h2>
+  <p>Humblebrag wolf hot chicken tumeric four dollar toast 3 wolf moon gochujang vinyl VHS cray street art authentic. Deep v skateboard la croix master cleanse DIY ramps ennui marfa slow-carb. Asymmetrical roof party farm-to-table Topico Chico espresso with 3 wolf moon subway tile, offal +1 meggings neutra ramps normcore. Quinoa jean shorts +1, skateboard copper mug sustainable lumberjack. Man bun food truck street art vinyl whatever slow-carb migas sartorial beard locavore. Neutra blue bottle ugh hot chicken trust fund, artisan YOLO activated charcoal XOXO freegan roof party prism blog fixie.</p>
+</div>
+
+<div
+  id="iframe-container"
+>
+  <iframe>
+    <h2>I'm an iFrame!</h2>
+  </iframe>
+</div>

--- a/src/app/public/modules/adapter-service/fixtures/adapter-service.fixture.ts
+++ b/src/app/public/modules/adapter-service/fixtures/adapter-service.fixture.ts
@@ -1,0 +1,60 @@
+import {
+  Component,
+  ElementRef,
+  ViewChild
+} from '@angular/core';
+
+import {
+  SkyMediaBreakpoints
+} from '@skyux/core';
+
+import {
+  SkyCoreAdapterService
+} from '../adapter.service';
+
+import {
+  SkyFocusableChildrenOptions
+} from '../focusable-children-options';
+
+@Component({
+  selector: 'adapter-service-fixture',
+  templateUrl: './adapter-service.fixture.html'
+})
+export class AdapterServiceFixtureComponent {
+
+  @ViewChild('paragraphContainer')
+  public paragraphContainer: ElementRef;
+
+  constructor(
+    private adapterService: SkyCoreAdapterService
+  ) {}
+
+  public applyAutoFocus(elementRef: ElementRef): boolean {
+    return this.adapterService.applyAutoFocus(elementRef);
+  }
+
+  public toggleIframePointerEvents(enable: boolean): void {
+    this.adapterService.toggleIframePointerEvents(enable);
+  }
+
+  public getFocusableChildrenAndApplyFocus(
+    element: ElementRef,
+    containerSelector: string,
+    focusOnContainerIfNotFound?: boolean
+  ): void {
+    return this.adapterService.getFocusableChildrenAndApplyFocus(
+      element,
+      containerSelector,
+      focusOnContainerIfNotFound
+    );
+  }
+
+  public getFocusableChildren(element: HTMLElement, options?: SkyFocusableChildrenOptions): any[] {
+    return this.adapterService.getFocusableChildren(element, options);
+  }
+
+  public setParagraphContainerClass(breakpoint: SkyMediaBreakpoints): void {
+    this.adapterService.setResponsiveContainerClass(this.paragraphContainer, breakpoint);
+  }
+
+}

--- a/src/app/public/modules/adapter-service/fixtures/adapter-service.fixtures.module.ts
+++ b/src/app/public/modules/adapter-service/fixtures/adapter-service.fixtures.module.ts
@@ -1,0 +1,25 @@
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyCoreAdapterService
+} from '../adapter.service';
+
+import {
+  AdapterServiceFixtureComponent
+} from './adapter-service.fixture';
+
+@NgModule({
+  declarations: [
+    AdapterServiceFixtureComponent
+  ],
+  imports: [],
+  providers: [
+    SkyCoreAdapterService
+  ],
+  exports: [
+    AdapterServiceFixtureComponent
+  ]
+})
+export class SkyAdapterServiceFixturesModule { }

--- a/src/app/public/modules/adapter-service/focusable-children-options.ts
+++ b/src/app/public/modules/adapter-service/focusable-children-options.ts
@@ -1,0 +1,18 @@
+
+/**
+ * Options for getting focusable children.
+ */
+export interface SkyFocusableChildrenOptions {
+
+  /**
+   * By default, the `getFocusableChildren()` function will filter out elements with
+   * a `tabIndex` of `-1`. Setting `ignoreTabIndex = true` will ignore this filter.
+   */
+  ignoreTabIndex?: boolean;
+
+  /**
+   * By default, the `getFocusableChildren()` function will only return visible elements.
+   * Setting `ignoreVisibility = true` will ignore this filter.
+   */
+  ignoreVisibility?: boolean;
+}

--- a/src/app/public/modules/adapter-service/index.ts
+++ b/src/app/public/modules/adapter-service/index.ts
@@ -1,2 +1,3 @@
-export * from './adapter.module';
 export * from './adapter.service';
+export * from './adapter.module';
+export * from './focusable-children-options';


### PR DESCRIPTION
Added ability to call `getFocusableChildren()` and ignore tabIndex and visibility. Should not be a breaking change, since these are new optional arguments.