### PR TITLE
Added basic title service

### DIFF
--- a/src/app/public/modules/index.ts
+++ b/src/app/public/modules/index.ts
@@ -6,5 +6,6 @@ export * from './media-query';
 export * from './mutation';
 export * from './numeric';
 export * from './percent-pipe';
+export * from './title';
 export * from './ui-config';
 export * from './window';

--- a/src/app/public/modules/title/index.ts
+++ b/src/app/public/modules/title/index.ts
@@ -1,0 +1,2 @@
+export * from './set-title-args';
+export * from './title.service';

--- a/src/app/public/modules/title/set-title-args.ts
+++ b/src/app/public/modules/title/set-title-args.ts
@@ -1,0 +1,5 @@
+export interface SkyAppSetTitleArgs {
+
+  titleParts: string[];
+
+}

--- a/src/app/public/modules/title/title.service.spec.ts
+++ b/src/app/public/modules/title/title.service.spec.ts
@@ -1,0 +1,53 @@
+import {
+  SkyAppTitleService
+} from './title.service';
+
+describe('Title service', () => {
+
+  let titleSvc: SkyAppTitleService;
+  let testTitle: string;
+
+  beforeEach(() => {
+    titleSvc = new SkyAppTitleService({
+      getTitle: () => testTitle,
+      setTitle: (newTitle: string) => testTitle = newTitle
+    } as any);
+  });
+
+  afterEach(() => {
+    testTitle = undefined;
+  });
+
+  it('should set the document title', () => {
+    titleSvc.setTitle({
+      titleParts: [
+        'Part 1',
+        'Part 2'
+      ]
+    });
+
+    expect(testTitle).toBe('Part 1 - Part 2');
+  });
+
+  it('should ignore invalid arguments', () => {
+    titleSvc.setTitle({
+      titleParts: [
+        'Part 3',
+        'Part 4'
+      ]
+    });
+
+    expect(testTitle).toBe('Part 3 - Part 4');
+
+    titleSvc.setTitle(undefined);
+
+    expect(testTitle).toBe('Part 3 - Part 4');
+
+    titleSvc.setTitle({
+      titleParts: undefined
+    });
+
+    expect(testTitle).toBe('Part 3 - Part 4');
+  });
+
+});

--- a/src/app/public/modules/title/title.service.ts
+++ b/src/app/public/modules/title/title.service.ts
@@ -1,0 +1,32 @@
+import {
+  Injectable
+} from '@angular/core';
+
+import {
+  Title
+} from '@angular/platform-browser';
+
+import {
+  SkyAppSetTitleArgs
+} from './set-title-args';
+
+/**
+ * Provides a method for setting a formatted title on the current window.
+ */
+@Injectable()
+export class SkyAppTitleService {
+
+  constructor(private title: Title) { }
+
+  /**
+   * Sets the title on the current window.
+   * @param args An array of title parts. The parts will be concatenated with a hyphen between
+   * each part.
+   */
+  public setTitle(args: SkyAppSetTitleArgs): void {
+    if (args && args.titleParts) {
+      this.title.setTitle(args.titleParts.join(' - '));
+    }
+  }
+
+}


### PR DESCRIPTION
While this service is functional, its main intent is to provide a way to inject alternate methods for updating the window's title, such as using the omnibar's set title logic to include the selected service and number of unread notifications.