### PR TITLE
Added interface properties to `SkyViewkeeperHostOptions`

### DIFF
--- a/src/app/public/modules/viewkeeper/viewkeeper-host-options.ts
+++ b/src/app/public/modules/viewkeeper/viewkeeper-host-options.ts
@@ -7,4 +7,16 @@ import {
 } from './viewkeeper-options';
 
 @Injectable()
-export class SkyViewkeeperHostOptions implements SkyViewkeeperOptions { }
+export class SkyViewkeeperHostOptions implements SkyViewkeeperOptions {
+  public setWidth?: boolean;
+
+  public el?: HTMLElement;
+
+  public boundaryEl?: HTMLElement;
+
+  public verticalOffset?: number;
+
+  public verticalOffsetEl?: HTMLElement;
+
+  public viewportMarginTop?: number;
+}

--- a/src/app/public/modules/viewkeeper/viewkeeper-host-options.ts
+++ b/src/app/public/modules/viewkeeper/viewkeeper-host-options.ts
@@ -8,11 +8,11 @@ import {
 
 @Injectable()
 export class SkyViewkeeperHostOptions implements SkyViewkeeperOptions {
-  public setWidth?: boolean;
+  public boundaryEl?: HTMLElement;
 
   public el?: HTMLElement;
 
-  public boundaryEl?: HTMLElement;
+  public setWidth?: boolean;
 
   public verticalOffset?: number;
 

--- a/src/app/public/modules/viewkeeper/viewkeeper-options.ts
+++ b/src/app/public/modules/viewkeeper/viewkeeper-options.ts
@@ -3,12 +3,11 @@
  */
 export interface SkyViewkeeperOptions {
   /**
-   * Specifies whether to set the width of the viewkeeper element to the width of its
-   * host element. Otherwise, if the element does not have an explicit width specified,
-   * the element would collapse horizontally as a result of fixing the element to the top
-   * of the viewport.
+   * The element that defines the bounds in which to keep the element in view. When the
+   * boundary element is scrolled out of view, the viewkeeper element will be scrolled
+   * out of view.
    */
-  setWidth?: boolean;
+  boundaryEl?: HTMLElement;
 
   /**
    * The element to keep in view.
@@ -16,11 +15,12 @@ export interface SkyViewkeeperOptions {
   el?: HTMLElement;
 
   /**
-   * The element that defines the bounds in which to keep the element in view. When the
-   * boundary element is scrolled out of view, the viewkeeper element will be scrolled
-   * out of view.
+   * Specifies whether to set the width of the viewkeeper element to the width of its
+   * host element. Otherwise, if the element does not have an explicit width specified,
+   * the element would collapse horizontally as a result of fixing the element to the top
+   * of the viewport.
    */
-  boundaryEl?: HTMLElement;
+  setWidth?: boolean;
 
   /**
    * Reserved space in pixels above the viewkeeper element.


### PR DESCRIPTION
This fixes an issue with the Angular AoT compiler since it doesn't recognize properties not declared on a class even if it implements an interface with those properties.