### PR TITLE
Fix providers to work in lazy-loaded modules

### DIFF
--- a/src/app/public/modules/numeric/numeric.service.ts
+++ b/src/app/public/modules/numeric/numeric.service.ts
@@ -20,7 +20,7 @@ import {
 } from './numeric-symbol';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'any'
 })
 export class SkyNumericService {
 


### PR DESCRIPTION
See: https://indepth.dev/posts/1090/angulars-root-and-any-provider-scopes

Since `SkyNumericService` accesses `SkyLibResourcesService` under the hood, we'll need to provide a copy of the numeric service for both the root and any lazy-loaded modules that import it.

Related: https://github.com/blackbaud/skyux-i18n/pull/108